### PR TITLE
上传完文件后用一个新的input替换掉旧的input，否则继续上传同一个文件会导致不能触发change事件

### DIFF
--- a/src/upload.js
+++ b/src/upload.js
@@ -162,6 +162,15 @@ define(function(require, exports, module) {
     return this;
   };
 
+  Uploader.prototype.refreshInput = function() {
+    //replace the input element, or the same file can not to be uploaded
+    var newInput = this.input.clone();
+    this.input.before(newInput);
+    this.input.remove();
+    this.input = newInput;
+    this.bind();
+  }
+
   // handle change event
   // when value in file input changed
   Uploader.prototype.change = function(callback) {
@@ -174,17 +183,23 @@ define(function(require, exports, module) {
 
   // handle when upload success
   Uploader.prototype.success = function(callback) {
-    if (!callback) {
-      return this;
-    }
-    this.settings.success = callback;
+    this.settings.success = function(response) {
+      this.refreshInput();
+      if (callback) {
+        callback(response);
+      }
+    };
     return this;
   };
 
   // handle when upload success
   Uploader.prototype.error = function(callback) {
-    if (!callback) return this;
-    this.settings.error = callback;
+    this.settings.error = function(fileName) {
+      if (callback) {
+        this.refreshInput();
+        callback(response);
+      }
+    };
     return this;
   };
 


### PR DESCRIPTION
在#11 提到的不能继续上传同样文件的问题，是因为上传一个文件后再继续上传同一个文件不会触发change事件，所以在上传完成后clone出来一个input，然后替换掉原来的input就可以解决这个问题了。
