### PR TITLE
修正用Ajax方式上传文件时FormData对象的构造

### DIFF
--- a/src/upload.js
+++ b/src/upload.js
@@ -54,11 +54,7 @@ define(function(require, exports, module) {
     var data = this.settings.data;
     this.form.append(createInputs(data));
     if (window.FormData) {
-      this._formdata = new FormData();
-      for (var key in data) {
-        this._formdata.append(key, data[key]);
-      }
-      this._formdata.append('_uploader_', 'formdata');
+      this.form.append(createInputs({'_uploader_': 'formdata'}));
     } else {
       this.form.append(createInputs({'_uploader_': 'iframe'}));
     }
@@ -130,9 +126,9 @@ define(function(require, exports, module) {
   // prepare for submiting form
   Uploader.prototype.submit = function() {
     var self = this;
-    if (self._formdata && self._files) {
-      // clone a new FormData
-      var form = new FormData(self._formdata);
+    if (window.FormData && self._files) {
+      // build a FormData
+      var form = new FormData(self.form.get(0));
       // use FormData to upload
       $.each(self._files, function(i, file) {
         form.append(self.settings.name, file);


### PR DESCRIPTION
https://github.com/aralejs/upload/commit/a3d5d844c7ac3bd73351bdd208016ba2be2751c4#L0R135 这里对FormData对象的构造方式不正确，会导致上传时带的data参数丢失
