### PR TITLE
dist目录下文件存在错误

### DIFF
--- a/dist/upload-debug.js
+++ b/dist/upload-debug.js
@@ -118,9 +118,10 @@ define("arale/upload/1.0.1/upload-debug", [ "$-debug" ], function(require, expor
             // build a FormData
             var form = new FormData(self.form.get(0));
             // use FormData to upload
-            $.each(self._files, function(i, file) {
-                form.append(self.settings.name, file);
-            });
+            //$.each(self._files, function(i, file) {
+                //form.append(self.settings.name, file);
+                form.append(self.settings.name, self._files);
+            //});
             $.ajax({
                 url: self.settings.action,
                 type: "post",


### PR DESCRIPTION
上传单图的时候，发现服务器接收到2个文件。 

src中的代码正确的，但此文件存在问题，建议/dist/upload-debug.js和/dist/upload.js重新build下。
