### PR TITLE
动态计算input控件高度

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,6 +102,9 @@ Uploader.prototype.bind = function() {
       width: $trigger.outerWidth(),
       height: $trigger.outerHeight()
     });
+    self.input.css({
+      height: $trigger.outerHeight()
+    });
   });
   self.bindInput();
 };


### PR DESCRIPTION
form表单有动态计算，可表单下面的input文件控件没有动态计算
在如下场景会出现问题
dom元素没有确定位置而先new一个对象后，form表单会自动定位但由于input控件height=0造成还是无法上传文件
例如弹窗上传
先new一个对象可以避免多次创建dom元素和绑定事件
当弹窗位置确定后form表单位置正确，input控件height不正确
